### PR TITLE
Make re2 an optional peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,15 @@
   ],
   "dependencies": {
     "ip-regex": "^4.3.0",
-    "re2": "^1.16.0",
     "tlds": "^1.217.0"
+  },
+  "peerDependencies": {
+    "re2": "^1.16.0"
+  },
+  "peerDependenciesMeta": {
+    "re2": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@babel/cli": "^7.12.16",


### PR DESCRIPTION
Address issue #23. This is basically Option 1 in #18.