### PR TITLE
fix: match ipv6 urls

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -60,8 +60,8 @@ module.exports = (options) => {
     options.strict
       ? strictTld
       : options.tlds
-      ? `(?:${options.tlds.sort((a, b) => b.length - a.length).join('|')})`
-      : defaultTlds
+        ? `(?:${options.tlds.sort((a, b) => b.length - a.length).join('|')})`
+        : defaultTlds
   })${options.trailingPeriod ? '\\.?' : ''}`;
 
   let disallowedChars = '\\s"';
@@ -86,7 +86,7 @@ module.exports = (options) => {
   let regex = `(?:${protocol}|www\\.)${auth}(?:`;
   if (options.localhost) regex += 'localhost|';
   if (options.ipv4) regex += `${ipv4}|`;
-  if (options.ipv6) regex += `${ipv6}|`;
+  if (options.ipv6) regex += `${ipv6}|\\[${ipv6}\\]|`;
   regex += `${host}${domain}${tld})${port}${path}`;
 
   // Add option to return the regex string instead of a RegExp

--- a/test/test.js
+++ b/test/test.js
@@ -444,11 +444,13 @@ test('do not match URLs with non-strict mode', (t) => {
 
 test('IPv4', (t) => {
   t.true(urlRegex().test('1.1.1.1'));
+  t.deepEqual(urlRegex().match('http://127.0.0.1/'), ['http://127.0.0.1/']);
   t.false(urlRegex({ ipv4: false }).test('1.1.1.1'));
 });
 
 test('IPv6', (t) => {
   t.true(urlRegex().test('2606:4700:4700::1111'));
+  t.deepEqual(urlRegex().match('http://[::1]/'), ['http://[::1]/']);
   t.false(urlRegex({ ipv6: false }).test('2606:4700:4700::1111'));
 });
 


### PR DESCRIPTION
A fix for https://github.com/spamscanner/url-regex-safe/issues/34
## Checklist

- [x] I have ensured my pull request is not behind the main or master branch of the original repository.
- [x] I have rebased all commits where necessary so that reviewing this pull request can be done without having to merge it first.
- [x] I have written a commit message that passes commitlint linting.
- [x] I have ensured that my code changes pass linting tests.
- [x] I have ensured that my code changes pass unit tests.
- [x] I have described my pull request and the reasons for code changes along with context if necessary.
